### PR TITLE
Add UI search, data entry modal, and expanded tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,104 @@
             max-width: 200px;
             z-index: 100;
         }
+
+        .text-search input {
+            padding: 4px 6px;
+            min-width: 180px;
+        }
+
+        .primary-button,
+        .secondary-button {
+            align-self: center;
+            padding: 6px 12px;
+            border-radius: 4px;
+            border: none;
+            cursor: pointer;
+            font-weight: bold;
+        }
+
+        .primary-button {
+            background-color: #1f77b4;
+            color: #fff;
+        }
+
+        .secondary-button {
+            background-color: #e0e0e0;
+            color: #333;
+        }
+
+        .modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 200;
+        }
+
+        .modal.hidden {
+            display: none;
+        }
+
+        .modal-content {
+            background: #fff;
+            border-radius: 6px;
+            width: min(600px, 90%);
+            max-height: 80%;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+        }
+
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 16px;
+            border-bottom: 1px solid #e5e5e5;
+        }
+
+        .modal-header button {
+            background: none;
+            border: none;
+            font-size: 24px;
+            line-height: 1;
+            cursor: pointer;
+        }
+
+        .modal-body {
+            padding: 16px;
+            overflow-y: auto;
+            display: grid;
+            gap: 12px;
+        }
+
+        .form-field {
+            display: flex;
+            flex-direction: column;
+            font: 14px sans-serif;
+            gap: 6px;
+        }
+
+        .form-field input,
+        .form-field textarea {
+            padding: 6px 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font: 14px sans-serif;
+        }
+
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            padding: 12px 16px 16px;
+            border-top: 1px solid #e5e5e5;
+        }
     </style>
 </head>
 
@@ -121,12 +219,32 @@
                 class="filter">
                 <option value="All">All</option>
             </select></label>
+        <div class="text-search">
+            <label class="filter-label" for="text-search-input" style="font-weight: bold; gap: 8px;">
+                Search
+                <input id="text-search-input" type="text" placeholder="Search by any text" />
+            </label>
+        </div>
+        <button id="open-add-modal" type="button" class="primary-button">Add Entry</button>
     </div>
     <div id="zoom-control">
         <label>Zoom<input type="range" id="zoom-slider" min="1" max="4" step="0.1" value="1"></label>
     </div>
     <div id="chart"></div>
     <div class="tooltip" id="tooltip"></div>
+    <div id="modal-overlay" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Add New Rights Entry</h3>
+                <button type="button" id="close-modal" aria-label="Close">&times;</button>
+            </div>
+            <form id="add-data-form" class="modal-body"></form>
+            <div class="modal-actions">
+                <button type="button" id="cancel-add" class="secondary-button">Cancel</button>
+                <button type="submit" form="add-data-form" class="primary-button">Save</button>
+            </div>
+        </div>
+    </div>
 
     <script>
         const leagueIcons = {};
@@ -134,8 +252,12 @@
         const svg = d3.select('#chart').append('svg').attr('width', '100%').attr('height', '100%');
         const graph = svg.append('g').attr('class', 'graph');
         const tooltip = d3.select('#tooltip');
+        const modal = d3.select('#modal-overlay');
+        const addForm = d3.select('#add-data-form');
         let allData = [], width = 0, height = 0;
         let selectedNode = null;
+        let searchTerm = '';
+        let columnNames = [];
 
         function updateDimensions() {
             const rect = document.getElementById('chart').getBoundingClientRect();
@@ -153,13 +275,96 @@
             ];
             mappings.forEach(({ id, key }) => {
                 const select = d3.select('#' + id);
-                const values = Array.from(new Set(allData.map(d => d[key]))).sort();
+                const previousValue = select.property('value') || 'All';
+                select.selectAll('option:not([value="All"])').remove();
+                const values = Array.from(new Set(allData.map(d => d[key]).filter(Boolean))).sort();
                 values.forEach(v => select.append('option').attr('value', v).text(v));
+                const shouldSelect = values.includes(previousValue) ? previousValue : 'All';
+                select.property('value', shouldSelect);
             });
+        }
+
+        function updateDatalists() {
+            const datalistConfig = {
+                League: 'league-options',
+                Company: 'company-options'
+            };
+            Object.entries(datalistConfig).forEach(([column, id]) => {
+                let list = d3.select('#' + id);
+                if (list.empty()) {
+                    list = d3.select('body').append('datalist').attr('id', id);
+                }
+                const values = Array.from(new Set(allData.map(d => d[column]).filter(Boolean))).sort();
+                list.selectAll('option').remove();
+                values.forEach(value => list.append('option').attr('value', value));
+            });
+        }
+
+        function buildAddForm() {
+            addForm.selectAll('*').remove();
+            const textAreaFields = new Set(['Contents']);
+            columnNames.forEach(column => {
+                const fieldWrapper = addForm.append('label').attr('class', 'form-field');
+                fieldWrapper.append('span').text(column);
+                if (textAreaFields.has(column)) {
+                    fieldWrapper.append('textarea').attr('name', column).attr('rows', 3).attr('placeholder', column);
+                } else {
+                    const input = fieldWrapper.append('input').attr('type', 'text').attr('name', column).attr('placeholder', column);
+                    if (column === 'League') input.attr('list', 'league-options');
+                    if (column === 'Company') input.attr('list', 'company-options');
+                }
+            });
+        }
+
+        function openModal() {
+            modal.classed('hidden', false);
+        }
+
+        function closeModal() {
+            modal.classed('hidden', true);
+            const formNode = addForm.node();
+            if (formNode) formNode.reset();
+        }
+
+        function downloadUpdatedCsv() {
+            const csvContent = d3.csvFormat(allData);
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'rights.csv';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        }
+
+        function handleFormSubmit(event) {
+            event.preventDefault();
+            const formData = new FormData(addForm.node());
+            const newEntry = {};
+            columnNames.forEach(column => {
+                const value = formData.get(column);
+                newEntry[column] = value ? value.trim() : '';
+            });
+            allData.push(newEntry);
+            populateFilters();
+            updateDatalists();
+            drawChart();
+            downloadUpdatedCsv();
+            closeModal();
         }
 
         function attachListeners() {
             d3.selectAll('.filter').on('change', () => drawChart());
+            d3.select('#text-search-input').on('input', function () {
+                searchTerm = this.value.toLowerCase();
+                drawChart();
+            });
+            d3.select('#open-add-modal').on('click', openModal);
+            d3.select('#close-modal').on('click', closeModal);
+            d3.select('#cancel-add').on('click', closeModal);
+            addForm.on('submit', handleFormSubmit);
             d3.select('#zoom-slider').on('input', function () {
                 const scale = +this.value;
                 svg.transition().duration(200).call(zoomBehavior.scaleTo, scale);
@@ -203,7 +408,12 @@
             return clean;
         }).then(data => {
             allData = data;
-            populateFilters(); attachListeners(); drawChart();
+            columnNames = Object.keys(allData[0] || {});
+            populateFilters();
+            updateDatalists();
+            buildAddForm();
+            attachListeners();
+            drawChart();
         }).catch(err => {
             console.error('CSV load error:', err);
             d3.select('#chart').append('p').text('Failed to load data.');
@@ -224,7 +434,10 @@
         }
 
         function drawChart() {
-            updateDimensions(); svg.selectAll('*').remove(); svg.append(() => graph.node());
+            updateDimensions();
+            svg.selectAll('*').remove();
+            graph.selectAll('*').remove();
+            svg.append(() => graph.node());
             const fl = d3.select('#filter-league').property('value');
             const fr = d3.select('#filter-right').property('value');
             const rg = d3.select('#filter-region').property('value');
@@ -237,6 +450,7 @@
                 && (rg === 'All' || d.Region === rg)
                 && (fp === 'All' || d['Parent Company'] === fp)
                 && (fc === 'All' || d.Company === fc)
+                && (!searchTerm || Object.values(d).some(value => (value || '').toString().toLowerCase().includes(searchTerm)))
             );
 
             const nodesMap = new Map(), links = [];
@@ -250,7 +464,14 @@
                 };
                 const names = { league: d.League, right: d.Rights, region: d.Region, parent: d['Parent Company'], company: d.Company };
                 Object.entries(ids).forEach(([t, id]) => {
-                    if (!nodesMap.has(id)) nodesMap.set(id, { id, name: names[t], type: t, contents: d.Contents });
+                    if (!nodesMap.has(id)) {
+                        nodesMap.set(id, { id, name: names[t], type: t, contents: d.Contents, details: { ...d } });
+                    } else {
+                        const existing = nodesMap.get(id);
+                        existing.details = existing.details || {};
+                        Object.assign(existing.details, d);
+                        if (t === 'company' && d.Contents) existing.contents = d.Contents;
+                    }
                 });
                 links.push({ source: ids.league, target: ids.right });
                 links.push({ source: ids.right, target: ids.region });
@@ -307,7 +528,7 @@
 
             nodeSel.filter(d => d.type === 'company')
                 .on('mouseover', (event, d) => {
-                    tooltip.html(d.contents || '')
+                    tooltip.html(buildTooltipContent(d.details))
                         .style('left', event.pageX + 10 + 'px')
                         .style('top', event.pageY + 10 + 'px')
                         .style('opacity', 1);
@@ -332,6 +553,24 @@
 
             applyVisibility(1);
             d3.select('#zoom-slider').property('value', 1);
+        }
+
+        function buildTooltipContent(details) {
+            if (!details) return '';
+            const fields = [
+                { key: 'Contents', label: 'Contents' },
+                { key: 'Timeline', label: 'Timeline' },
+                { key: '30 sec Ad USD', label: '30 sec Ad USD' },
+                { key: 'Contract Value', label: 'Contract Value' },
+                { key: 'Production', label: 'Production' },
+                { key: 'Production Location', label: 'Production Location' },
+                { key: 'Production Company', label: 'Production Company' }
+            ];
+            const parts = fields.map(({ key, label }) => {
+                const value = details[key];
+                return value ? `<div><strong>${label}:</strong> ${value}</div>` : '';
+            }).filter(Boolean);
+            return parts.join('') || '<div>No additional details</div>';
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a text search field and improve filter repopulation for dynamic data
- introduce an "Add Entry" modal with CSV download to capture new records and field suggestions
- show extended company details in tooltips and refine redraw behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de804ba93c832e88b18c0af5ab4057